### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MCP3208       KEYWORD1
-Channel       KEYWORD1
+MCP3208	KEYWORD1
+Channel	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-read          KEYWORD2
-testSplSpeed  KEYWORD2
-toAnalog      KEYWORD2
-toDigital     KEYWORD2
-getVref       KEYWORD2
-getAnalogRes  KEYWORD2
+read	KEYWORD2
+testSplSpeed	KEYWORD2
+toAnalog	KEYWORD2
+toDigital	KEYWORD2
+getVref	KEYWORD2
+getAnalogRes	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -28,5 +28,5 @@ getAnalogRes  KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-kResBits      LITERAL1
-kRes          LITERAL1
+kResBits	LITERAL1
+kRes	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords