### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,7 @@ Channel	KEYWORD1
 calibrate	KEYWORD2
 read	KEYWORD2
 read_if	KEYWORD2
-readn KEYWORD2
+readn	KEYWORD2
 readn_if	KEYWORD2
 testSplSpeed	KEYWORD2
 toAnalog	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords